### PR TITLE
Add .NET Clean Architecture skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 # LotusApi2025
+
+This repository contains a minimal Clean Architecture setup for a .NET Web API using MySQL.
+
+## Structure
+- `src/Domain` – domain entities and logic
+- `src/Application` – application interfaces and use cases
+- `src/Infrastructure` – Entity Framework Core setup and repository implementations
+- `src/Api` – ASP.NET Core Web API project
+
+## Building
+Ensure the .NET 8 SDK is installed. Then run:
+
+```bash
+cd src/Api
+ dotnet build
+```
+
+## Running
+Update `appsettings.json` or environment variables with the `Default` connection string for MySQL, then run:
+
+```bash
+dotnet run
+```
+
+Swagger UI will be available in development at `/swagger`.

--- a/src/Api/Api.csproj
+++ b/src/Api/Api.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Application/Application.csproj" />
+    <ProjectReference Include="../Infrastructure/Infrastructure.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+  </ItemGroup>
+</Project>

--- a/src/Api/Controllers/UsersController.cs
+++ b/src/Api/Controllers/UsersController.cs
@@ -1,0 +1,33 @@
+using Application.Interfaces;
+using Domain.Entities;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Api.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class UsersController : ControllerBase
+    {
+        private readonly IUserRepository _repository;
+
+        public UsersController(IUserRepository repository)
+        {
+            _repository = repository;
+        }
+
+        [HttpGet("{id}")]
+        public async Task<ActionResult<User?>> Get(int id)
+        {
+            var user = await _repository.GetByIdAsync(id);
+            if (user == null) return NotFound();
+            return Ok(user);
+        }
+
+        [HttpPost]
+        public async Task<ActionResult> Post(User user)
+        {
+            await _repository.AddAsync(user);
+            return CreatedAtAction(nameof(Get), new { id = user.Id }, user);
+        }
+    }
+}

--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -1,0 +1,25 @@
+using Infrastructure;
+using Microsoft.OpenApi.Models;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+builder.Services.AddInfrastructure(builder.Configuration);
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(c =>
+{
+    c.SwaggerDoc("v1", new OpenApiInfo { Title = "Lotus API", Version = "v1" });
+});
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.MapControllers();
+
+app.Run();

--- a/src/Api/appsettings.json
+++ b/src/Api/appsettings.json
@@ -1,0 +1,13 @@
+{
+  "ConnectionStrings": {
+    "Default": "server=localhost;database=lotus;user=root;password=secret"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/Application/Application.csproj
+++ b/src/Application/Application.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Domain/Domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Application/Interfaces/IUserRepository.cs
+++ b/src/Application/Interfaces/IUserRepository.cs
@@ -1,0 +1,10 @@
+using Domain.Entities;
+
+namespace Application.Interfaces
+{
+    public interface IUserRepository
+    {
+        Task<User?> GetByIdAsync(int id);
+        Task AddAsync(User user);
+    }
+}

--- a/src/Domain/Domain.csproj
+++ b/src/Domain/Domain.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/src/Domain/Entities/User.cs
+++ b/src/Domain/Entities/User.cs
@@ -1,0 +1,9 @@
+namespace Domain.Entities
+{
+    public class User
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string Email { get; set; } = string.Empty;
+    }
+}

--- a/src/Infrastructure/Data/AppDbContext.cs
+++ b/src/Infrastructure/Data/AppDbContext.cs
@@ -1,0 +1,13 @@
+using Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace Infrastructure.Data
+{
+    public class AppDbContext : DbContext
+    {
+        public AppDbContext(DbContextOptions<AppDbContext> options)
+            : base(options) { }
+
+        public DbSet<User> Users => Set<User>();
+    }
+}

--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Domain/Domain.csproj" />
+    <ProjectReference Include="../Application/Application.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.0" />
+  </ItemGroup>
+</Project>

--- a/src/Infrastructure/Repositories/UserRepository.cs
+++ b/src/Infrastructure/Repositories/UserRepository.cs
@@ -1,0 +1,28 @@
+using Application.Interfaces;
+using Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Infrastructure.Data;
+
+namespace Infrastructure.Repositories
+{
+    public class UserRepository : IUserRepository
+    {
+        private readonly AppDbContext _context;
+
+        public UserRepository(AppDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<User?> GetByIdAsync(int id)
+        {
+            return await _context.Users.FindAsync(id);
+        }
+
+        public async Task AddAsync(User user)
+        {
+            _context.Users.Add(user);
+            await _context.SaveChangesAsync();
+        }
+    }
+}

--- a/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -1,0 +1,20 @@
+using Application.Interfaces;
+using Infrastructure.Data;
+using Infrastructure.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Infrastructure
+{
+    public static class ServiceCollectionExtensions
+    {
+        public static IServiceCollection AddInfrastructure(this IServiceCollection services, IConfiguration configuration)
+        {
+            var connectionString = configuration.GetConnectionString("Default") ?? string.Empty;
+            services.AddDbContext<AppDbContext>(options => options.UseMySql(connectionString, ServerVersion.AutoDetect(connectionString)));
+            services.AddScoped<IUserRepository, UserRepository>();
+            return services;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- set up Clean Architecture folders for .NET API
- add EF Core with MySQL support
- configure basic UsersController and dependency injection
- provide README with build and run instructions

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888df43fcac8321be54ced654f490f7