### PR TITLE
Add CRUD support for customer registrations

### DIFF
--- a/src/Api/Controllers/BaseEntityController.cs
+++ b/src/Api/Controllers/BaseEntityController.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using Application.Common.Commands;
 using Application.Common.Queries;
 using Domain.Common;
@@ -40,6 +42,35 @@ namespace Api.Controllers
         {
             var created = await Mediator.Send(new CreateEntityCommand<TEntity>(entity), cancellationToken);
             return CreatedAtAction(nameof(GetById), new { id = GetEntityId(created) }, created);
+        }
+
+        [HttpPut("{id}")]
+        public virtual async Task<ActionResult<TEntity>> Update(TKey id, [FromBody] TEntity entity, CancellationToken cancellationToken)
+        {
+            if (!EqualityComparer<TKey>.Default.Equals(id, ((IEntity<TKey>)entity).Id))
+            {
+                return BadRequest();
+            }
+
+            var updated = await Mediator.Send(new UpdateEntityCommand<TEntity, TKey>(id, entity), cancellationToken);
+            if (updated == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(updated);
+        }
+
+        [HttpDelete("{id}")]
+        public virtual async Task<IActionResult> Delete(TKey id, CancellationToken cancellationToken)
+        {
+            var deleted = await Mediator.Send(new DeleteEntityCommand<TEntity, TKey>(id), cancellationToken);
+            if (!deleted)
+            {
+                return NotFound();
+            }
+
+            return NoContent();
         }
 
         protected virtual object? GetEntityId(TEntity entity)

--- a/src/Application/Common/Commands/DeleteEntityCommand.cs
+++ b/src/Application/Common/Commands/DeleteEntityCommand.cs
@@ -1,0 +1,34 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Application.Common.Interfaces;
+using Domain.Common;
+using MediatR;
+
+namespace Application.Common.Commands
+{
+    public record DeleteEntityCommand<TEntity, TKey>(TKey Id) : IRequest<bool> where TEntity : class, IEntity<TKey>;
+
+    public class DeleteEntityCommandHandler<TEntity, TKey> : IRequestHandler<DeleteEntityCommand<TEntity, TKey>, bool> where TEntity : class, IEntity<TKey>
+    {
+        private readonly IAppDbContext _context;
+
+        public DeleteEntityCommandHandler(IAppDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<bool> Handle(DeleteEntityCommand<TEntity, TKey> request, CancellationToken cancellationToken)
+        {
+            var set = _context.Set<TEntity>();
+            var entity = await set.FindAsync(new object?[] { request.Id }, cancellationToken);
+            if (entity == null)
+            {
+                return false;
+            }
+
+            set.Remove(entity);
+            await _context.SaveChangesAsync(cancellationToken);
+            return true;
+        }
+    }
+}

--- a/src/Application/Common/Commands/UpdateEntityCommand.cs
+++ b/src/Application/Common/Commands/UpdateEntityCommand.cs
@@ -1,0 +1,35 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Application.Common.Interfaces;
+using Domain.Common;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Application.Common.Commands
+{
+    public record UpdateEntityCommand<TEntity, TKey>(TKey Id, TEntity Entity) : IRequest<TEntity?> where TEntity : class, IEntity<TKey>;
+
+    public class UpdateEntityCommandHandler<TEntity, TKey> : IRequestHandler<UpdateEntityCommand<TEntity, TKey>, TEntity?> where TEntity : class, IEntity<TKey>
+    {
+        private readonly IAppDbContext _context;
+
+        public UpdateEntityCommandHandler(IAppDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<TEntity?> Handle(UpdateEntityCommand<TEntity, TKey> request, CancellationToken cancellationToken)
+        {
+            var set = _context.Set<TEntity>();
+            var existing = await set.FindAsync(new object?[] { request.Id }, cancellationToken);
+            if (existing == null)
+            {
+                return null;
+            }
+
+            _context.Entry(existing).CurrentValues.SetValues(request.Entity);
+            await _context.SaveChangesAsync(cancellationToken);
+            return existing;
+        }
+    }
+}

--- a/src/Application/Common/Interfaces/IAppDbContext.cs
+++ b/src/Application/Common/Interfaces/IAppDbContext.cs
@@ -1,6 +1,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace Application.Common.Interfaces
 {
@@ -9,5 +10,7 @@ namespace Application.Common.Interfaces
         DbSet<TEntity> Set<TEntity>() where TEntity : class;
 
         Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
+
+        EntityEntry<TEntity> Entry<TEntity>(TEntity entity) where TEntity : class;
     }
 }

--- a/src/Infrastructure/Data/AppDbContext.cs
+++ b/src/Infrastructure/Data/AppDbContext.cs
@@ -1,6 +1,7 @@
 using Application.Common.Interfaces;
 using Domain.Entities;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace Infrastructure.Data
 {
@@ -26,6 +27,11 @@ namespace Infrastructure.Data
         public DbSet<FpxBank> FpxBanks => Set<FpxBank>();
         public DbSet<EntrySource> EntrySources => Set<EntrySource>();
         public DbSet<EmailOtpTransaction> EmailOtpTransactions => Set<EmailOtpTransaction>();
+
+        public EntityEntry<TEntity> Entry<TEntity>(TEntity entity) where TEntity : class
+        {
+            return base.Entry(entity);
+        }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {


### PR DESCRIPTION
## Summary
- add generic update and delete commands for entities handled by MediatR
- extend the base entity controller with PUT and DELETE endpoints to complete CRUD coverage for customer registrations
- expose DbContext entry access through the application abstraction to support entity updates

## Testing
- not run (dotnet CLI unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68d9d927771c8321b4af6c72b52a3b51