### PR TITLE
Prefix project namespaces with LotusFive

### DIFF
--- a/src/Api/Controllers/BaseEntityController.cs
+++ b/src/Api/Controllers/BaseEntityController.cs
@@ -1,13 +1,13 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Application.Common.Commands;
-using Application.Common.Queries;
-using Domain.Common;
+using LotusFive.Application.Common.Commands;
+using LotusFive.Application.Common.Queries;
+using LotusFive.Domain.Common;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Api.Controllers
+namespace LotusFive.Api.Controllers
 {
     public abstract class BaseEntityController<TEntity, TKey> : ControllerBase where TEntity : class, IEntity<TKey>
     {

--- a/src/Api/Controllers/BeneficiaryDetailsController.cs
+++ b/src/Api/Controllers/BeneficiaryDetailsController.cs
@@ -1,8 +1,8 @@
-using Domain.Entities;
+using LotusFive.Domain.Entities;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Api.Controllers
+namespace LotusFive.Api.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]

--- a/src/Api/Controllers/BranchesController.cs
+++ b/src/Api/Controllers/BranchesController.cs
@@ -1,8 +1,8 @@
-using Domain.Entities;
+using LotusFive.Domain.Entities;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Api.Controllers
+namespace LotusFive.Api.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]

--- a/src/Api/Controllers/CampaignsController.cs
+++ b/src/Api/Controllers/CampaignsController.cs
@@ -1,8 +1,8 @@
-using Domain.Entities;
+using LotusFive.Domain.Entities;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Api.Controllers
+namespace LotusFive.Api.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]

--- a/src/Api/Controllers/CountriesController.cs
+++ b/src/Api/Controllers/CountriesController.cs
@@ -1,8 +1,8 @@
-using Domain.Entities;
+using LotusFive.Domain.Entities;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Api.Controllers
+namespace LotusFive.Api.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]

--- a/src/Api/Controllers/CurrencyRatesController.cs
+++ b/src/Api/Controllers/CurrencyRatesController.cs
@@ -1,8 +1,8 @@
-using Domain.Entities;
+using LotusFive.Domain.Entities;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Api.Controllers
+namespace LotusFive.Api.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]

--- a/src/Api/Controllers/CustomerRegistrationsController.cs
+++ b/src/Api/Controllers/CustomerRegistrationsController.cs
@@ -1,8 +1,8 @@
-using Domain.Entities;
+using LotusFive.Domain.Entities;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Api.Controllers
+namespace LotusFive.Api.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]

--- a/src/Api/Controllers/CustomerTransactionsController.cs
+++ b/src/Api/Controllers/CustomerTransactionsController.cs
@@ -1,8 +1,8 @@
-using Domain.Entities;
+using LotusFive.Domain.Entities;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Api.Controllers
+namespace LotusFive.Api.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]

--- a/src/Api/Controllers/DocumentsController.cs
+++ b/src/Api/Controllers/DocumentsController.cs
@@ -1,8 +1,8 @@
-using Domain.Entities;
+using LotusFive.Domain.Entities;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Api.Controllers
+namespace LotusFive.Api.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]

--- a/src/Api/Controllers/EmailOtpTransactionsController.cs
+++ b/src/Api/Controllers/EmailOtpTransactionsController.cs
@@ -1,12 +1,12 @@
 using System.Collections.Generic;
-using Application.Common.Commands;
-using Application.Common.Queries;
-using Application.EmailOtpTransactions.Queries;
-using Domain.Entities;
+using LotusFive.Application.Common.Commands;
+using LotusFive.Application.Common.Queries;
+using LotusFive.Application.EmailOtpTransactions.Queries;
+using LotusFive.Domain.Entities;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Api.Controllers
+namespace LotusFive.Api.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]

--- a/src/Api/Controllers/EntrySourcesController.cs
+++ b/src/Api/Controllers/EntrySourcesController.cs
@@ -1,8 +1,8 @@
-using Domain.Entities;
+using LotusFive.Domain.Entities;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Api.Controllers
+namespace LotusFive.Api.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]

--- a/src/Api/Controllers/FpxBanksController.cs
+++ b/src/Api/Controllers/FpxBanksController.cs
@@ -1,8 +1,8 @@
-using Domain.Entities;
+using LotusFive.Domain.Entities;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Api.Controllers
+namespace LotusFive.Api.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]

--- a/src/Api/Controllers/FpxConfigurationsController.cs
+++ b/src/Api/Controllers/FpxConfigurationsController.cs
@@ -1,8 +1,8 @@
-using Domain.Entities;
+using LotusFive.Domain.Entities;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Api.Controllers
+namespace LotusFive.Api.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]

--- a/src/Api/Controllers/FpxResponsesController.cs
+++ b/src/Api/Controllers/FpxResponsesController.cs
@@ -1,8 +1,8 @@
-using Domain.Entities;
+using LotusFive.Domain.Entities;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Api.Controllers
+namespace LotusFive.Api.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]

--- a/src/Api/Controllers/NationalitiesController.cs
+++ b/src/Api/Controllers/NationalitiesController.cs
@@ -1,8 +1,8 @@
-using Domain.Entities;
+using LotusFive.Domain.Entities;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Api.Controllers
+namespace LotusFive.Api.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]

--- a/src/Api/Controllers/OtpTransactionsController.cs
+++ b/src/Api/Controllers/OtpTransactionsController.cs
@@ -1,12 +1,12 @@
 using System.Collections.Generic;
-using Application.Common.Commands;
-using Application.Common.Queries;
-using Application.OtpTransactions.Queries;
-using Domain.Entities;
+using LotusFive.Application.Common.Commands;
+using LotusFive.Application.Common.Queries;
+using LotusFive.Application.OtpTransactions.Queries;
+using LotusFive.Domain.Entities;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Api.Controllers
+namespace LotusFive.Api.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]

--- a/src/Api/Controllers/PromotionsController.cs
+++ b/src/Api/Controllers/PromotionsController.cs
@@ -1,8 +1,8 @@
-using Domain.Entities;
+using LotusFive.Domain.Entities;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Api.Controllers
+namespace LotusFive.Api.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]

--- a/src/Api/Controllers/TransferFeesController.cs
+++ b/src/Api/Controllers/TransferFeesController.cs
@@ -1,8 +1,8 @@
-using Domain.Entities;
+using LotusFive.Domain.Entities;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Api.Controllers
+namespace LotusFive.Api.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]

--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -1,5 +1,5 @@
-using Application;
-using Infrastructure;
+using LotusFive.Application;
+using LotusFive.Infrastructure;
 using Microsoft.OpenApi.Models;
 
 var builder = WebApplication.CreateBuilder(args);

--- a/src/Application/Common/Commands/CreateEntityCommand.cs
+++ b/src/Application/Common/Commands/CreateEntityCommand.cs
@@ -1,9 +1,9 @@
 using System.Threading;
 using System.Threading.Tasks;
-using Application.Common.Interfaces;
+using LotusFive.Application.Common.Interfaces;
 using MediatR;
 
-namespace Application.Common.Commands
+namespace LotusFive.Application.Common.Commands
 {
     public record CreateEntityCommand<TEntity>(TEntity Entity) : IRequest<TEntity> where TEntity : class;
 

--- a/src/Application/Common/Commands/DeleteEntityCommand.cs
+++ b/src/Application/Common/Commands/DeleteEntityCommand.cs
@@ -1,10 +1,10 @@
 using System.Threading;
 using System.Threading.Tasks;
-using Application.Common.Interfaces;
-using Domain.Common;
+using LotusFive.Application.Common.Interfaces;
+using LotusFive.Domain.Common;
 using MediatR;
 
-namespace Application.Common.Commands
+namespace LotusFive.Application.Common.Commands
 {
     public record DeleteEntityCommand<TEntity, TKey>(TKey Id) : IRequest<bool> where TEntity : class, IEntity<TKey>;
 

--- a/src/Application/Common/Commands/UpdateEntityCommand.cs
+++ b/src/Application/Common/Commands/UpdateEntityCommand.cs
@@ -1,11 +1,11 @@
 using System.Threading;
 using System.Threading.Tasks;
-using Application.Common.Interfaces;
-using Domain.Common;
+using LotusFive.Application.Common.Interfaces;
+using LotusFive.Domain.Common;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 
-namespace Application.Common.Commands
+namespace LotusFive.Application.Common.Commands
 {
     public record UpdateEntityCommand<TEntity, TKey>(TKey Id, TEntity Entity) : IRequest<TEntity?> where TEntity : class, IEntity<TKey>;
 

--- a/src/Application/Common/Interfaces/IAppDbContext.cs
+++ b/src/Application/Common/Interfaces/IAppDbContext.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 
-namespace Application.Common.Interfaces
+namespace LotusFive.Application.Common.Interfaces
 {
     public interface IAppDbContext
     {

--- a/src/Application/Common/Queries/GetAllEntitiesQuery.cs
+++ b/src/Application/Common/Queries/GetAllEntitiesQuery.cs
@@ -1,11 +1,11 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Application.Common.Interfaces;
+using LotusFive.Application.Common.Interfaces;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 
-namespace Application.Common.Queries
+namespace LotusFive.Application.Common.Queries
 {
     public record GetAllEntitiesQuery<TEntity>() : IRequest<IEnumerable<TEntity>> where TEntity : class;
 

--- a/src/Application/Common/Queries/GetEntityByIdQuery.cs
+++ b/src/Application/Common/Queries/GetEntityByIdQuery.cs
@@ -1,10 +1,10 @@
 using System.Threading;
 using System.Threading.Tasks;
-using Application.Common.Interfaces;
-using Domain.Common;
+using LotusFive.Application.Common.Interfaces;
+using LotusFive.Domain.Common;
 using MediatR;
 
-namespace Application.Common.Queries
+namespace LotusFive.Application.Common.Queries
 {
     public record GetEntityByIdQuery<TEntity, TKey>(TKey Id) : IRequest<TEntity?> where TEntity : class, IEntity<TKey>;
 

--- a/src/Application/EmailOtpTransactions/Queries/GetEmailOtpTransactionQuery.cs
+++ b/src/Application/EmailOtpTransactions/Queries/GetEmailOtpTransactionQuery.cs
@@ -1,10 +1,10 @@
 using System.Threading;
 using System.Threading.Tasks;
-using Application.Common.Interfaces;
-using Domain.Entities;
+using LotusFive.Application.Common.Interfaces;
+using LotusFive.Domain.Entities;
 using MediatR;
 
-namespace Application.EmailOtpTransactions.Queries
+namespace LotusFive.Application.EmailOtpTransactions.Queries
 {
     public record GetEmailOtpTransactionQuery(string EmailId, string Otp) : IRequest<EmailOtpTransaction?>;
 

--- a/src/Application/OtpTransactions/Queries/GetOtpTransactionQuery.cs
+++ b/src/Application/OtpTransactions/Queries/GetOtpTransactionQuery.cs
@@ -1,10 +1,10 @@
 using System.Threading;
 using System.Threading.Tasks;
-using Application.Common.Interfaces;
-using Domain.Entities;
+using LotusFive.Application.Common.Interfaces;
+using LotusFive.Domain.Entities;
 using MediatR;
 
-namespace Application.OtpTransactions.Queries
+namespace LotusFive.Application.OtpTransactions.Queries
 {
     public record GetOtpTransactionQuery(string MobileNo, string Otp) : IRequest<OtpTransaction?>;
 

--- a/src/Application/ServiceCollectionExtensions.cs
+++ b/src/Application/ServiceCollectionExtensions.cs
@@ -2,7 +2,7 @@ using System.Reflection;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Application
+namespace LotusFive.Application
 {
     public static class ServiceCollectionExtensions
     {

--- a/src/Domain/Common/IEntity.cs
+++ b/src/Domain/Common/IEntity.cs
@@ -1,4 +1,4 @@
-namespace Domain.Common
+namespace LotusFive.Domain.Common
 {
     public interface IEntity<TKey>
     {

--- a/src/Domain/Entities/BeneficiaryDetail.cs
+++ b/src/Domain/Entities/BeneficiaryDetail.cs
@@ -1,9 +1,9 @@
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using Domain.Common;
+using LotusFive.Domain.Common;
 
-namespace Domain.Entities
+namespace LotusFive.Domain.Entities
 {
     [Table("benficiarydetail")]
     public class BeneficiaryDetail : IEntity<string>

--- a/src/Domain/Entities/Branch.cs
+++ b/src/Domain/Entities/Branch.cs
@@ -1,8 +1,8 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using Domain.Common;
+using LotusFive.Domain.Common;
 
-namespace Domain.Entities
+namespace LotusFive.Domain.Entities
 {
     [Table("branch")]
     public class Branch : IEntity<string>

--- a/src/Domain/Entities/Campaign.cs
+++ b/src/Domain/Entities/Campaign.cs
@@ -1,9 +1,9 @@
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using Domain.Common;
+using LotusFive.Domain.Common;
 
-namespace Domain.Entities
+namespace LotusFive.Domain.Entities
 {
     [Table("campaign")]
     public class Campaign : IEntity<string>

--- a/src/Domain/Entities/Country.cs
+++ b/src/Domain/Entities/Country.cs
@@ -1,8 +1,8 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using Domain.Common;
+using LotusFive.Domain.Common;
 
-namespace Domain.Entities
+namespace LotusFive.Domain.Entities
 {
     [Table("country")]
     public class Country : IEntity<int>

--- a/src/Domain/Entities/CurrencyRate.cs
+++ b/src/Domain/Entities/CurrencyRate.cs
@@ -1,8 +1,8 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using Domain.Common;
+using LotusFive.Domain.Common;
 
-namespace Domain.Entities
+namespace LotusFive.Domain.Entities
 {
     [Table("currencyrate")]
     public class CurrencyRate : IEntity<string>

--- a/src/Domain/Entities/CustomerRegistration.cs
+++ b/src/Domain/Entities/CustomerRegistration.cs
@@ -1,9 +1,9 @@
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using Domain.Common;
+using LotusFive.Domain.Common;
 
-namespace Domain.Entities
+namespace LotusFive.Domain.Entities
 {
     [Table("customerregistration")]
     public class CustomerRegistration : IEntity<string>

--- a/src/Domain/Entities/CustomerTransaction.cs
+++ b/src/Domain/Entities/CustomerTransaction.cs
@@ -1,9 +1,9 @@
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using Domain.Common;
+using LotusFive.Domain.Common;
 
-namespace Domain.Entities
+namespace LotusFive.Domain.Entities
 {
     [Table("customertransaction")]
     public class CustomerTransaction : IEntity<string>

--- a/src/Domain/Entities/Document.cs
+++ b/src/Domain/Entities/Document.cs
@@ -1,9 +1,9 @@
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using Domain.Common;
+using LotusFive.Domain.Common;
 
-namespace Domain.Entities
+namespace LotusFive.Domain.Entities
 {
     [Table("documents")]
     public class Document : IEntity<string>

--- a/src/Domain/Entities/EmailOtpTransaction.cs
+++ b/src/Domain/Entities/EmailOtpTransaction.cs
@@ -2,7 +2,7 @@ using System;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
-namespace Domain.Entities
+namespace LotusFive.Domain.Entities
 {
     [Table("email_otp_transaction")]
     public class EmailOtpTransaction

--- a/src/Domain/Entities/EntrySource.cs
+++ b/src/Domain/Entities/EntrySource.cs
@@ -1,8 +1,8 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using Domain.Common;
+using LotusFive.Domain.Common;
 
-namespace Domain.Entities
+namespace LotusFive.Domain.Entities
 {
     [Table("entrysource")]
     public class EntrySource : IEntity<int>

--- a/src/Domain/Entities/FpxBank.cs
+++ b/src/Domain/Entities/FpxBank.cs
@@ -1,8 +1,8 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using Domain.Common;
+using LotusFive.Domain.Common;
 
-namespace Domain.Entities
+namespace LotusFive.Domain.Entities
 {
     [Table("fpxbank")]
     public class FpxBank : IEntity<int>

--- a/src/Domain/Entities/FpxConfiguration.cs
+++ b/src/Domain/Entities/FpxConfiguration.cs
@@ -1,8 +1,8 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using Domain.Common;
+using LotusFive.Domain.Common;
 
-namespace Domain.Entities
+namespace LotusFive.Domain.Entities
 {
     [Table("fpxconfiguration")]
     public class FpxConfiguration : IEntity<int>

--- a/src/Domain/Entities/FpxResponse.cs
+++ b/src/Domain/Entities/FpxResponse.cs
@@ -1,8 +1,8 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using Domain.Common;
+using LotusFive.Domain.Common;
 
-namespace Domain.Entities
+namespace LotusFive.Domain.Entities
 {
     [Table("fpxresponse")]
     public class FpxResponse : IEntity<string>

--- a/src/Domain/Entities/Nationality.cs
+++ b/src/Domain/Entities/Nationality.cs
@@ -1,8 +1,8 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using Domain.Common;
+using LotusFive.Domain.Common;
 
-namespace Domain.Entities
+namespace LotusFive.Domain.Entities
 {
     [Table("nationality")]
     public class Nationality : IEntity<int>

--- a/src/Domain/Entities/OtpTransaction.cs
+++ b/src/Domain/Entities/OtpTransaction.cs
@@ -2,7 +2,7 @@ using System;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
-namespace Domain.Entities
+namespace LotusFive.Domain.Entities
 {
     [Table("otptransaction")]
     public class OtpTransaction

--- a/src/Domain/Entities/Promotion.cs
+++ b/src/Domain/Entities/Promotion.cs
@@ -1,9 +1,9 @@
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using Domain.Common;
+using LotusFive.Domain.Common;
 
-namespace Domain.Entities
+namespace LotusFive.Domain.Entities
 {
     [Table("promotion")]
     public class Promotion : IEntity<string>

--- a/src/Domain/Entities/TransferFee.cs
+++ b/src/Domain/Entities/TransferFee.cs
@@ -1,8 +1,8 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using Domain.Common;
+using LotusFive.Domain.Common;
 
-namespace Domain.Entities
+namespace LotusFive.Domain.Entities
 {
     [Table("transferfee")]
     public class TransferFee : IEntity<string>

--- a/src/Infrastructure/Data/AppDbContext.cs
+++ b/src/Infrastructure/Data/AppDbContext.cs
@@ -1,9 +1,9 @@
-using Application.Common.Interfaces;
-using Domain.Entities;
+using LotusFive.Application.Common.Interfaces;
+using LotusFive.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 
-namespace Infrastructure.Data
+namespace LotusFive.Infrastructure.Data
 {
     public class AppDbContext : DbContext, IAppDbContext
     {

--- a/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -1,10 +1,10 @@
-using Application.Common.Interfaces;
-using Infrastructure.Data;
+using LotusFive.Application.Common.Interfaces;
+using LotusFive.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Infrastructure
+namespace LotusFive.Infrastructure
 {
     public static class ServiceCollectionExtensions
     {


### PR DESCRIPTION
## Summary
- prefix all project namespaces with the LotusFive root namespace across API, Application, Domain, and Infrastructure layers
- update using directives to reference the new LotusFive-prefixed namespaces

## Testing
- dotnet build (fails: dotnet CLI is not installed in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d9dd0c31ac8321898b465d52cc6760