### PR TITLE
Implement JWT authentication and secure API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,16 @@ cd src/Api
 
 ## Running
 Update `appsettings.json` or environment variables with the `Default` connection string for MySQL, then run:
- 
+
 cd src/Api
- 
+
 dotnet run
- 
+
 
 Swagger UI will be available in development at `/swagger`.
+
+## Authentication
+
+JWT bearer authentication is enabled for the API. Update the `Authentication` section in `appsettings.json` (or override the values with environment variables) with your desired issuer, audience, secret key, token lifetime, and the list of in-memory users allowed to sign in.
+
+To obtain an access token, send a `POST` request to `/api/auth/login` with a JSON body containing `username` and `password`. Use the returned bearer token in the `Authorization` header (`Authorization: Bearer <token>`) for subsequent requests.

--- a/src/Api/Api.csproj
+++ b/src/Api/Api.csproj
@@ -10,6 +10,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 </Project>

--- a/src/Api/Controllers/AuthController.cs
+++ b/src/Api/Controllers/AuthController.cs
@@ -1,0 +1,40 @@
+using System.ComponentModel.DataAnnotations;
+using System.Threading;
+using System.Threading.Tasks;
+using LotusFive.Application.Authentication;
+using LotusFive.Application.Authentication.Commands;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace LotusFive.Api.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class AuthController : ControllerBase
+    {
+        private readonly IMediator _mediator;
+
+        public AuthController(IMediator mediator)
+        {
+            _mediator = mediator;
+        }
+
+        [HttpPost("login")]
+        [AllowAnonymous]
+        public async Task<ActionResult<AuthenticationResult>> Login([FromBody] LoginRequest request, CancellationToken cancellationToken)
+        {
+            var result = await _mediator.Send(new AuthenticateUserCommand(request.Username, request.Password), cancellationToken);
+            if (result is null)
+            {
+                return Unauthorized();
+            }
+
+            return Ok(result);
+        }
+    }
+
+    public record LoginRequest(
+        [property: Required] string Username,
+        [property: Required] string Password);
+}

--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -1,17 +1,83 @@
+using System;
+using System.Text;
 using LotusFive.Application;
+using LotusFive.Application.Authentication;
 using LotusFive.Infrastructure;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.Authorization;
+using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddControllers();
+builder.Services.AddControllers(options =>
+{
+    var policy = new AuthorizationPolicyBuilder()
+        .RequireAuthenticatedUser()
+        .Build();
+    options.Filters.Add(new AuthorizeFilter(policy));
+});
 builder.Services.AddApplication();
+builder.Services.Configure<AuthenticationSettings>(builder.Configuration.GetSection("Authentication"));
+
+var authenticationSettings = new AuthenticationSettings();
+builder.Configuration.GetSection("Authentication").Bind(authenticationSettings);
+
+if (string.IsNullOrWhiteSpace(authenticationSettings.SecretKey))
+{
+    throw new InvalidOperationException("Authentication secret key must be configured.");
+}
+
+builder.Services.AddSingleton(authenticationSettings);
 builder.Services.AddInfrastructure(builder.Configuration);
+
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        var validateIssuer = !string.IsNullOrWhiteSpace(authenticationSettings.Issuer);
+        var validateAudience = !string.IsNullOrWhiteSpace(authenticationSettings.Audience);
+        options.TokenValidationParameters = new TokenValidationParameters
+        {
+            ValidateIssuer = validateIssuer,
+            ValidIssuer = validateIssuer ? authenticationSettings.Issuer : null,
+            ValidateAudience = validateAudience,
+            ValidAudience = validateAudience ? authenticationSettings.Audience : null,
+            ValidateIssuerSigningKey = true,
+            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(authenticationSettings.SecretKey)),
+            ValidateLifetime = true,
+            ClockSkew = TimeSpan.Zero
+        };
+    });
+builder.Services.AddAuthorization();
 
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(c =>
 {
     c.SwaggerDoc("v1", new OpenApiInfo { Title = "Lotus API", Version = "v1" });
+    c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+    {
+        Description = "JWT Authorization header using the Bearer scheme.",
+        Name = "Authorization",
+        In = ParameterLocation.Header,
+        Type = SecuritySchemeType.Http,
+        Scheme = "bearer",
+        BearerFormat = "JWT"
+    });
+    c.AddSecurityRequirement(new OpenApiSecurityRequirement
+    {
+        {
+            new OpenApiSecurityScheme
+            {
+                Reference = new OpenApiReference
+                {
+                    Type = ReferenceType.SecurityScheme,
+                    Id = "Bearer"
+                }
+            },
+            Array.Empty<string>()
+        }
+    });
 });
 
 var app = builder.Build();
@@ -28,6 +94,9 @@ if (app.Environment.IsDevelopment())
     app.UseSwagger();
     app.UseSwaggerUI();
 }
+
+app.UseAuthentication();
+app.UseAuthorization();
 
 app.MapControllers();
 

--- a/src/Api/appsettings.json
+++ b/src/Api/appsettings.json
@@ -9,5 +9,23 @@
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Authentication": {
+    "SecretKey": "ChangeThisSecretKey1234567890",
+    "Issuer": "LotusApi",
+    "Audience": "LotusApiClients",
+    "TokenLifetimeMinutes": 120,
+    "Users": [
+      {
+        "Username": "admin",
+        "Password": "P@ssword1",
+        "Roles": ["Administrator"]
+      },
+      {
+        "Username": "auditor",
+        "Password": "Audit#2025",
+        "Roles": ["Reader"]
+      }
+    ]
+  }
 }

--- a/src/Application/Authentication/AuthenticationResult.cs
+++ b/src/Application/Authentication/AuthenticationResult.cs
@@ -1,0 +1,6 @@
+using System;
+
+namespace LotusFive.Application.Authentication
+{
+    public record AuthenticationResult(string Token, DateTime ExpiresAtUtc);
+}

--- a/src/Application/Authentication/AuthenticationSettings.cs
+++ b/src/Application/Authentication/AuthenticationSettings.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+
+namespace LotusFive.Application.Authentication
+{
+    public class AuthenticationSettings
+    {
+        public string SecretKey { get; set; } = string.Empty;
+
+        public string Issuer { get; set; } = string.Empty;
+
+        public string Audience { get; set; } = string.Empty;
+
+        public int TokenLifetimeMinutes { get; set; } = 60;
+
+        public List<AuthenticationUser> Users { get; set; } = new();
+    }
+
+    public class AuthenticationUser
+    {
+        public string Username { get; set; } = string.Empty;
+
+        public string Password { get; set; } = string.Empty;
+
+        public List<string> Roles { get; set; } = new();
+    }
+}

--- a/src/Application/Authentication/Commands/AuthenticateUserCommand.cs
+++ b/src/Application/Authentication/Commands/AuthenticateUserCommand.cs
@@ -1,0 +1,34 @@
+using System.Threading;
+using System.Threading.Tasks;
+using LotusFive.Application.Authentication;
+using MediatR;
+
+namespace LotusFive.Application.Authentication.Commands
+{
+    public record AuthenticateUserCommand(string Username, string Password) : IRequest<AuthenticationResult?>;
+
+    public class AuthenticateUserCommandHandler : IRequestHandler<AuthenticateUserCommand, AuthenticationResult?>
+    {
+        private readonly IUserCredentialValidator _credentialValidator;
+        private readonly IJwtTokenGenerator _tokenGenerator;
+
+        public AuthenticateUserCommandHandler(
+            IUserCredentialValidator credentialValidator,
+            IJwtTokenGenerator tokenGenerator)
+        {
+            _credentialValidator = credentialValidator;
+            _tokenGenerator = tokenGenerator;
+        }
+
+        public Task<AuthenticationResult?> Handle(AuthenticateUserCommand request, CancellationToken cancellationToken)
+        {
+            if (!_credentialValidator.TryValidateCredentials(request.Username, request.Password, out var roles))
+            {
+                return Task.FromResult<AuthenticationResult?>(null);
+            }
+
+            var result = _tokenGenerator.GenerateToken(request.Username, roles);
+            return Task.FromResult<AuthenticationResult?>(result);
+        }
+    }
+}

--- a/src/Application/Authentication/IJwtTokenGenerator.cs
+++ b/src/Application/Authentication/IJwtTokenGenerator.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace LotusFive.Application.Authentication
+{
+    public interface IJwtTokenGenerator
+    {
+        AuthenticationResult GenerateToken(string username, IReadOnlyCollection<string> roles);
+    }
+}

--- a/src/Application/Authentication/IUserCredentialValidator.cs
+++ b/src/Application/Authentication/IUserCredentialValidator.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace LotusFive.Application.Authentication
+{
+    public interface IUserCredentialValidator
+    {
+        bool TryValidateCredentials(string username, string password, out IReadOnlyCollection<string> roles);
+    }
+}

--- a/src/Infrastructure/Authentication/InMemoryUserCredentialValidator.cs
+++ b/src/Infrastructure/Authentication/InMemoryUserCredentialValidator.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using LotusFive.Application.Authentication;
+using Microsoft.Extensions.Options;
+
+namespace LotusFive.Infrastructure.Authentication
+{
+    public class InMemoryUserCredentialValidator : IUserCredentialValidator
+    {
+        private readonly IReadOnlyDictionary<string, (string Password, IReadOnlyCollection<string> Roles)> _users;
+
+        public InMemoryUserCredentialValidator(IOptions<AuthenticationSettings> options)
+        {
+            var settings = options.Value ?? throw new ArgumentNullException(nameof(options));
+            _users = (settings.Users ?? new List<AuthenticationUser>())
+                .Where(user => !string.IsNullOrWhiteSpace(user.Username))
+                .ToDictionary(
+                    user => user.Username,
+                    user =>
+                    {
+                        var roles = (user.Roles ?? new List<string>())
+                            .Where(role => !string.IsNullOrWhiteSpace(role))
+                            .Distinct(StringComparer.OrdinalIgnoreCase)
+                            .ToArray();
+                        return (user.Password ?? string.Empty, (IReadOnlyCollection<string>)roles);
+                    },
+                    StringComparer.OrdinalIgnoreCase);
+        }
+
+        public bool TryValidateCredentials(string username, string password, out IReadOnlyCollection<string> roles)
+        {
+            roles = Array.Empty<string>();
+            if (string.IsNullOrWhiteSpace(username) || string.IsNullOrEmpty(password))
+            {
+                return false;
+            }
+
+            if (!_users.TryGetValue(username, out var user) || !string.Equals(user.Password, password, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            roles = user.Roles;
+            return true;
+        }
+    }
+}

--- a/src/Infrastructure/Authentication/JwtTokenGenerator.cs
+++ b/src/Infrastructure/Authentication/JwtTokenGenerator.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Security.Claims;
+using System.Text;
+using LotusFive.Application.Authentication;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+
+namespace LotusFive.Infrastructure.Authentication
+{
+    public class JwtTokenGenerator : IJwtTokenGenerator
+    {
+        private readonly AuthenticationSettings _settings;
+
+        public JwtTokenGenerator(IOptions<AuthenticationSettings> options)
+        {
+            _settings = options.Value ?? throw new ArgumentNullException(nameof(options));
+            if (string.IsNullOrWhiteSpace(_settings.SecretKey))
+            {
+                throw new InvalidOperationException("Authentication secret key is not configured.");
+            }
+        }
+
+        public AuthenticationResult GenerateToken(string username, IReadOnlyCollection<string> roles)
+        {
+            var securityKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_settings.SecretKey));
+            var credentials = new SigningCredentials(securityKey, SecurityAlgorithms.HmacSha256);
+
+            var claims = new List<Claim>
+            {
+                new(ClaimTypes.Name, username)
+            };
+
+            if (roles != null && roles.Count > 0)
+            {
+                claims.AddRange(roles.Where(role => !string.IsNullOrWhiteSpace(role))
+                    .Select(role => new Claim(ClaimTypes.Role, role)));
+            }
+
+            var lifetimeMinutes = _settings.TokenLifetimeMinutes > 0 ? _settings.TokenLifetimeMinutes : 60;
+            var expires = DateTime.UtcNow.AddMinutes(lifetimeMinutes);
+
+            var token = new JwtSecurityToken(
+                issuer: string.IsNullOrWhiteSpace(_settings.Issuer) ? null : _settings.Issuer,
+                audience: string.IsNullOrWhiteSpace(_settings.Audience) ? null : _settings.Audience,
+                claims: claims,
+                expires: expires,
+                signingCredentials: credentials);
+
+            var handler = new JwtSecurityTokenHandler();
+            var tokenString = handler.WriteToken(token);
+
+            return new AuthenticationResult(tokenString, expires);
+        }
+    }
+}

--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -10,5 +10,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="7.0.3" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.0.3" />
   </ItemGroup>
 </Project>

--- a/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -1,5 +1,7 @@
+using LotusFive.Application.Authentication;
 using LotusFive.Application.Common.Interfaces;
 using LotusFive.Infrastructure.Data;
+using LotusFive.Infrastructure.Authentication;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -13,6 +15,8 @@ namespace LotusFive.Infrastructure
             var connectionString = configuration.GetConnectionString("Default") ?? string.Empty;
             services.AddDbContext<AppDbContext>(options => options.UseMySql(connectionString, ServerVersion.AutoDetect(connectionString)));
             services.AddScoped<IAppDbContext>(provider => provider.GetRequiredService<AppDbContext>());
+            services.AddSingleton<IUserCredentialValidator, InMemoryUserCredentialValidator>();
+            services.AddSingleton<IJwtTokenGenerator, JwtTokenGenerator>();
             return services;
         }
     }


### PR DESCRIPTION
## Summary
- introduce application-level abstractions and infrastructure services for issuing JWT tokens and validating credentials
- configure the API to enforce bearer authentication, expose a login endpoint, and update Swagger/OpenAPI with security metadata
- document authentication setup and provide sample in-memory users in appsettings

## Testing
- Unable to run `dotnet build LotusApi2025.sln` (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d9df052af883219f7a951fabc8b864