### PR TITLE
Add unit, component, and integration tests for API

### DIFF
--- a/LotusApi2025.sln
+++ b/LotusApi2025.sln
@@ -10,6 +10,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Domain", "src\Domain\Domain
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Infrastructure", "src\Infrastructure\Infrastructure.csproj", "{AA8C5CFC-C23E-49D4-B82B-2B3852341544}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Application.UnitTests", "tests\Application.UnitTests\Application.UnitTests.csproj", "{C7D4DA27-FADE-4C81-BDAB-881089AF65F8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Api.ComponentTests", "tests\Api.ComponentTests\Api.ComponentTests.csproj", "{8A07125E-DFDA-468D-AC50-76D6C90BFA47}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Api.IntegrationTests", "tests\Api.IntegrationTests\Api.IntegrationTests.csproj", "{7026E4F7-CA0B-4A88-8220-7024F93D73A3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -32,6 +38,18 @@ Global
 		{AA8C5CFC-C23E-49D4-B82B-2B3852341544}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AA8C5CFC-C23E-49D4-B82B-2B3852341544}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AA8C5CFC-C23E-49D4-B82B-2B3852341544}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C7D4DA27-FADE-4C81-BDAB-881089AF65F8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C7D4DA27-FADE-4C81-BDAB-881089AF65F8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C7D4DA27-FADE-4C81-BDAB-881089AF65F8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C7D4DA27-FADE-4C81-BDAB-881089AF65F8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8A07125E-DFDA-468D-AC50-76D6C90BFA47}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8A07125E-DFDA-468D-AC50-76D6C90BFA47}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8A07125E-DFDA-468D-AC50-76D6C90BFA47}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8A07125E-DFDA-468D-AC50-76D6C90BFA47}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7026E4F7-CA0B-4A88-8220-7024F93D73A3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7026E4F7-CA0B-4A88-8220-7024F93D73A3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7026E4F7-CA0B-4A88-8220-7024F93D73A3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7026E4F7-CA0B-4A88-8220-7024F93D73A3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -101,3 +101,7 @@ app.UseAuthorization();
 app.MapControllers();
 
 app.Run();
+
+public partial class Program
+{
+}

--- a/tests/Api.ComponentTests/Api.ComponentTests.csproj
+++ b/tests/Api.ComponentTests/Api.ComponentTests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/Api/Api.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Api.ComponentTests/Controllers/BaseEntityControllerTests.cs
+++ b/tests/Api.ComponentTests/Controllers/BaseEntityControllerTests.cs
@@ -1,0 +1,115 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using LotusFive.Api.Controllers;
+using LotusFive.Application.Common.Commands;
+using LotusFive.Application.Common.Queries;
+using LotusFive.Domain.Common;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+
+namespace LotusFive.Api.ComponentTests.Controllers;
+
+public class BaseEntityControllerTests
+{
+    private readonly Mock<IMediator> _mediatorMock = new();
+    private readonly TestEntityController _controller;
+
+    public BaseEntityControllerTests()
+    {
+        _controller = new TestEntityController(_mediatorMock.Object);
+    }
+
+    [Fact]
+    public async Task GetAll_ShouldReturnOkWithEntities()
+    {
+        // Arrange
+        var entities = new List<TestEntity> { new() { Id = 1, Name = "First" } };
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<GetAllEntitiesQuery<TestEntity>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(entities);
+
+        // Act
+        var result = await _controller.GetAll(CancellationToken.None);
+
+        // Assert
+        var okResult = result.Result.Should().BeOfType<OkObjectResult>().Which;
+        okResult.Value.Should().BeEquivalentTo(entities);
+    }
+
+    [Fact]
+    public async Task GetById_ShouldReturnNotFound_WhenEntityIsMissing()
+    {
+        // Arrange
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<GetEntityByIdQuery<TestEntity, int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((TestEntity?)null);
+
+        // Act
+        var result = await _controller.GetById(42, CancellationToken.None);
+
+        // Assert
+        result.Result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task Update_ShouldReturnBadRequest_WhenIdDoesNotMatchEntity()
+    {
+        // Arrange
+        var entity = new TestEntity { Id = 2, Name = "Mismatch" };
+
+        // Act
+        var result = await _controller.Update(1, entity, CancellationToken.None);
+
+        // Assert
+        result.Should().BeOfType<BadRequestResult>();
+        _mediatorMock.Verify(m => m.Send(It.IsAny<UpdateEntityCommand<TestEntity, int>>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Update_ShouldReturnOk_WhenMediatorReturnsEntity()
+    {
+        // Arrange
+        var entity = new TestEntity { Id = 5, Name = "Updated" };
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<UpdateEntityCommand<TestEntity, int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(entity);
+
+        // Act
+        var result = await _controller.Update(entity.Id, entity, CancellationToken.None);
+
+        // Assert
+        result.Should().BeOfType<OkObjectResult>().Which.Value.Should().Be(entity);
+    }
+
+    [Fact]
+    public async Task Delete_ShouldReturnNoContent_WhenMediatorConfirmsDeletion()
+    {
+        // Arrange
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<DeleteEntityCommand<TestEntity, int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        // Act
+        var result = await _controller.Delete(10, CancellationToken.None);
+
+        // Assert
+        result.Should().BeOfType<NoContentResult>();
+    }
+
+    private sealed class TestEntity : IEntity<int>
+    {
+        public int Id { get; set; }
+        public string? Name { get; set; }
+    }
+
+    private sealed class TestEntityController : BaseEntityController<TestEntity, int>
+    {
+        public TestEntityController(IMediator mediator) : base(mediator)
+        {
+        }
+    }
+}

--- a/tests/Api.IntegrationTests/Api.IntegrationTests.csproj
+++ b/tests/Api.IntegrationTests/Api.IntegrationTests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/Api/Api.csproj" />
+    <ProjectReference Include="../../src/Infrastructure/Infrastructure.csproj" />
+    <ProjectReference Include="../../src/Application/Application.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Api.IntegrationTests/BranchesEndpointTests.cs
+++ b/tests/Api.IntegrationTests/BranchesEndpointTests.cs
@@ -1,0 +1,49 @@
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using FluentAssertions;
+using LotusFive.Domain.Entities;
+using Xunit;
+
+namespace LotusFive.Api.IntegrationTests;
+
+public class BranchesEndpointTests : IClassFixture<Infrastructure.TestingWebApplicationFactory>
+{
+    private readonly Infrastructure.TestingWebApplicationFactory _factory;
+
+    public BranchesEndpointTests(Infrastructure.TestingWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task GetBranches_ShouldReturnSeededBranches()
+    {
+        // Arrange
+        var client = _factory.CreateClient();
+
+        // Act
+        var response = await client.GetAsync("/api/Branches");
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+        var branches = await response.Content.ReadFromJsonAsync<Branch[]>();
+        branches.Should().NotBeNull().And.HaveCountGreaterThan(0);
+        branches!.Should().Contain(b => b.Id == "HQ");
+    }
+
+    [Fact]
+    public async Task GetBranchById_ShouldReturnSingleBranch()
+    {
+        // Arrange
+        var client = _factory.CreateClient();
+
+        // Act
+        var response = await client.GetAsync("/api/Branches/HQ");
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+        var branch = await response.Content.ReadFromJsonAsync<Branch>();
+        branch.Should().NotBeNull();
+        branch!.Id.Should().Be("HQ");
+    }
+}

--- a/tests/Api.IntegrationTests/Infrastructure/TestAuthHandler.cs
+++ b/tests/Api.IntegrationTests/Infrastructure/TestAuthHandler.cs
@@ -1,0 +1,35 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace LotusFive.Api.IntegrationTests.Infrastructure;
+
+public class TestAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+{
+    public const string SchemeName = "Test";
+
+    public TestAuthHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder,
+        ISystemClock clock)
+        : base(options, logger, encoder, clock)
+    {
+    }
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        var identity = new ClaimsIdentity(new[]
+        {
+            new Claim(ClaimTypes.Name, "integration-tester"),
+            new Claim(ClaimTypes.Role, "Tester")
+        }, SchemeName);
+
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, SchemeName);
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+}

--- a/tests/Api.IntegrationTests/Infrastructure/TestingWebApplicationFactory.cs
+++ b/tests/Api.IntegrationTests/Infrastructure/TestingWebApplicationFactory.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using System.Linq;
+using LotusFive.Application.Common.Interfaces;
+using LotusFive.Domain.Entities;
+using LotusFive.Infrastructure.Data;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace LotusFive.Api.IntegrationTests.Infrastructure;
+
+public class TestingWebApplicationFactory : WebApplicationFactory<Program>
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Development");
+
+        builder.ConfigureAppConfiguration((context, config) =>
+        {
+            var settings = new Dictionary<string, string?>
+            {
+                ["Authentication:SecretKey"] = "integration-test-secret",
+                ["Authentication:Issuer"] = "TestIssuer",
+                ["Authentication:Audience"] = "TestAudience",
+                ["ConnectionStrings:Default"] = "UseInMemoryDatabase"
+            };
+
+            config.AddInMemoryCollection(settings!);
+        });
+
+        builder.ConfigureServices(services =>
+        {
+            services.RemoveAll(typeof(DbContextOptions<AppDbContext>));
+            services.RemoveAll<AppDbContext>();
+            services.RemoveAll<IAppDbContext>();
+
+            services.AddDbContext<AppDbContext>(options => options.UseInMemoryDatabase("LotusApiTests"));
+            services.AddScoped<IAppDbContext>(provider => provider.GetRequiredService<AppDbContext>());
+
+            services.AddAuthentication(options =>
+            {
+                options.DefaultAuthenticateScheme = TestAuthHandler.SchemeName;
+                options.DefaultChallengeScheme = TestAuthHandler.SchemeName;
+            }).AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(TestAuthHandler.SchemeName, _ => { });
+
+            using var scope = services.BuildServiceProvider().CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            context.Database.EnsureCreated();
+            SeedDatabase(context);
+        });
+    }
+
+    private static void SeedDatabase(AppDbContext context)
+    {
+        if (context.Branches.Any())
+        {
+            return;
+        }
+
+        context.Branches.AddRange(
+            new Branch { Id = "HQ", Name = "Headquarters", Address = "123 Main St" },
+            new Branch { Id = "KL", Name = "Kuala Lumpur", Address = "Kuala Lumpur" }
+        );
+
+        context.SaveChanges();
+    }
+}

--- a/tests/Application.UnitTests/Application.UnitTests.csproj
+++ b/tests/Application.UnitTests/Application.UnitTests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/Application/Application.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Application.UnitTests/Authentication/AuthenticateUserCommandHandlerTests.cs
+++ b/tests/Application.UnitTests/Authentication/AuthenticateUserCommandHandlerTests.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using LotusFive.Application.Authentication;
+using LotusFive.Application.Authentication.Commands;
+using Moq;
+using Xunit;
+
+namespace LotusFive.Application.UnitTests.Authentication;
+
+public class AuthenticateUserCommandHandlerTests
+{
+    private readonly Mock<IUserCredentialValidator> _credentialValidatorMock = new();
+    private readonly Mock<IJwtTokenGenerator> _tokenGeneratorMock = new();
+
+    [Fact]
+    public async Task Handle_ShouldReturnNull_WhenCredentialsAreInvalid()
+    {
+        // Arrange
+        var handler = CreateHandler();
+        var ignoredRoles = (IReadOnlyCollection<string>)new List<string>();
+        _credentialValidatorMock
+            .Setup(v => v.TryValidateCredentials("user", "wrong", out ignoredRoles))
+            .Returns(false);
+
+        var command = new AuthenticateUserCommand("user", "wrong");
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Should().BeNull();
+        _tokenGeneratorMock.Verify(g => g.GenerateToken(It.IsAny<string>(), It.IsAny<IReadOnlyCollection<string>>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnAuthenticationResult_WhenCredentialsAreValid()
+    {
+        // Arrange
+        var roles = (IReadOnlyCollection<string>)new List<string> { "Admin" };
+        var expected = new AuthenticationResult("token", System.DateTime.UtcNow.AddMinutes(5));
+        var handler = CreateHandler();
+
+        _credentialValidatorMock
+            .Setup(v => v.TryValidateCredentials("user", "pass", out roles))
+            .Returns(true);
+
+        _tokenGeneratorMock
+            .Setup(g => g.GenerateToken("user", roles))
+            .Returns(expected);
+
+        var command = new AuthenticateUserCommand("user", "pass");
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    private AuthenticateUserCommandHandler CreateHandler() => new(_credentialValidatorMock.Object, _tokenGeneratorMock.Object);
+}


### PR DESCRIPTION
## Summary
- add dedicated unit, component, and integration test projects for the Lotus API solution
- cover authentication command logic, base controller behavior, and branches HTTP endpoints with automated tests
- configure integration test infrastructure with in-memory EF Core and a test authentication handler while exposing Program for WebApplicationFactory

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68da73c5ca248321ab6fb8ead2e58a27