### PR TITLE
Add comprehensive unit tests for application handlers

### DIFF
--- a/tests/Api.ComponentTests/Controllers/BaseEntityControllerTests.cs
+++ b/tests/Api.ComponentTests/Controllers/BaseEntityControllerTests.cs
@@ -86,6 +86,21 @@ public class BaseEntityControllerTests
     }
 
     [Fact]
+    public async Task Update_ShouldReturnNotFound_WhenMediatorReturnsNull()
+    {
+        // Arrange
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<UpdateEntityCommand<TestEntity, int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((TestEntity?)null);
+
+        // Act
+        var result = await _controller.Update(5, new TestEntity { Id = 5 }, CancellationToken.None);
+
+        // Assert
+        result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
     public async Task Delete_ShouldReturnNoContent_WhenMediatorConfirmsDeletion()
     {
         // Arrange
@@ -98,6 +113,40 @@ public class BaseEntityControllerTests
 
         // Assert
         result.Should().BeOfType<NoContentResult>();
+    }
+
+    [Fact]
+    public async Task Delete_ShouldReturnNotFound_WhenMediatorReportsMissingEntity()
+    {
+        // Arrange
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<DeleteEntityCommand<TestEntity, int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        // Act
+        var result = await _controller.Delete(10, CancellationToken.None);
+
+        // Assert
+        result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task Create_ShouldReturnCreatedAtActionWithEntity()
+    {
+        // Arrange
+        var entity = new TestEntity { Id = 11, Name = "Created" };
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<CreateEntityCommand<TestEntity>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(entity);
+
+        // Act
+        var result = await _controller.Create(entity, CancellationToken.None);
+
+        // Assert
+        var created = result.Result.Should().BeOfType<CreatedAtActionResult>().Which;
+        created.ActionName.Should().Be(nameof(TestEntityController.GetById));
+        created.Value.Should().Be(entity);
+        created.RouteValues.Should().ContainKey("id").WhoseValue.Should().Be(entity.Id);
     }
 
     private sealed class TestEntity : IEntity<int>

--- a/tests/Application.UnitTests/Application.UnitTests.csproj
+++ b/tests/Application.UnitTests/Application.UnitTests.csproj
@@ -6,6 +6,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="xunit" Version="2.5.1" />

--- a/tests/Application.UnitTests/Common/Commands/CreateEntityCommandHandlerTests.cs
+++ b/tests/Application.UnitTests/Common/Commands/CreateEntityCommandHandlerTests.cs
@@ -1,0 +1,26 @@
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using LotusFive.Application.Common.Commands;
+using LotusFive.Application.UnitTests.Common;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace LotusFive.Application.UnitTests.Common.Commands;
+
+public class CreateEntityCommandHandlerTests
+{
+    [Fact]
+    public async Task Handle_ShouldAddEntityToContext()
+    {
+        await using var context = TestAppDbContextFactory.Create();
+        var handler = new CreateEntityCommandHandler<TestEntity>(context);
+        var entity = new TestEntity { Id = 1, Name = "Created" };
+
+        var result = await handler.Handle(new CreateEntityCommand<TestEntity>(entity), CancellationToken.None);
+
+        result.Should().BeSameAs(entity);
+        var stored = await context.TestEntities.SingleAsync();
+        stored.Should().BeEquivalentTo(entity);
+    }
+}

--- a/tests/Application.UnitTests/Common/Commands/DeleteEntityCommandHandlerTests.cs
+++ b/tests/Application.UnitTests/Common/Commands/DeleteEntityCommandHandlerTests.cs
@@ -1,0 +1,37 @@
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using LotusFive.Application.Common.Commands;
+using LotusFive.Application.UnitTests.Common;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace LotusFive.Application.UnitTests.Common.Commands;
+
+public class DeleteEntityCommandHandlerTests
+{
+    [Fact]
+    public async Task Handle_ShouldReturnFalse_WhenEntityDoesNotExist()
+    {
+        await using var context = TestAppDbContextFactory.Create();
+        var handler = new DeleteEntityCommandHandler<TestEntity, int>(context);
+
+        var result = await handler.Handle(new DeleteEntityCommand<TestEntity, int>(1), CancellationToken.None);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldRemoveEntity_WhenFound()
+    {
+        await using var context = TestAppDbContextFactory.Create();
+        context.TestEntities.Add(new TestEntity { Id = 9, Name = "ToDelete" });
+        await context.SaveChangesAsync();
+        var handler = new DeleteEntityCommandHandler<TestEntity, int>(context);
+
+        var result = await handler.Handle(new DeleteEntityCommand<TestEntity, int>(9), CancellationToken.None);
+
+        result.Should().BeTrue();
+        (await context.TestEntities.AnyAsync()).Should().BeFalse();
+    }
+}

--- a/tests/Application.UnitTests/Common/Commands/UpdateEntityCommandHandlerTests.cs
+++ b/tests/Application.UnitTests/Common/Commands/UpdateEntityCommandHandlerTests.cs
@@ -1,0 +1,41 @@
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using LotusFive.Application.Common.Commands;
+using LotusFive.Application.UnitTests.Common;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace LotusFive.Application.UnitTests.Common.Commands;
+
+public class UpdateEntityCommandHandlerTests
+{
+    [Fact]
+    public async Task Handle_ShouldReturnNull_WhenEntityIsMissing()
+    {
+        await using var context = TestAppDbContextFactory.Create();
+        var handler = new UpdateEntityCommandHandler<TestEntity, int>(context);
+
+        var result = await handler.Handle(new UpdateEntityCommand<TestEntity, int>(1, new TestEntity { Id = 1 }), CancellationToken.None);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldUpdateAndReturnEntity_WhenFound()
+    {
+        await using var context = TestAppDbContextFactory.Create();
+        context.TestEntities.Add(new TestEntity { Id = 5, Name = "Old" });
+        await context.SaveChangesAsync();
+        var handler = new UpdateEntityCommandHandler<TestEntity, int>(context);
+        var updatedEntity = new TestEntity { Id = 5, Name = "Updated" };
+
+        var result = await handler.Handle(new UpdateEntityCommand<TestEntity, int>(5, updatedEntity), CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result!.Name.Should().Be("Updated");
+
+        var stored = await context.TestEntities.AsNoTracking().SingleAsync();
+        stored.Name.Should().Be("Updated");
+    }
+}

--- a/tests/Application.UnitTests/Common/Queries/GetAllEntitiesQueryHandlerTests.cs
+++ b/tests/Application.UnitTests/Common/Queries/GetAllEntitiesQueryHandlerTests.cs
@@ -1,0 +1,40 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using LotusFive.Application.Common.Queries;
+using LotusFive.Application.UnitTests.Common;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace LotusFive.Application.UnitTests.Common.Queries;
+
+public class GetAllEntitiesQueryHandlerTests
+{
+    [Fact]
+    public async Task Handle_ShouldReturnEmptyCollection_WhenNoEntitiesExist()
+    {
+        await using var context = TestAppDbContextFactory.Create();
+        var handler = new GetAllEntitiesQueryHandler<TestEntity>(context);
+
+        var result = await handler.Handle(new GetAllEntitiesQuery<TestEntity>(), CancellationToken.None);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnAllEntities()
+    {
+        await using var context = TestAppDbContextFactory.Create();
+        context.TestEntities.AddRange(
+            new TestEntity { Id = 1, Name = "First" },
+            new TestEntity { Id = 2, Name = "Second" });
+        await context.SaveChangesAsync();
+        var handler = new GetAllEntitiesQueryHandler<TestEntity>(context);
+
+        var result = await handler.Handle(new GetAllEntitiesQuery<TestEntity>(), CancellationToken.None);
+
+        result.Should().HaveCount(2);
+        result.Select(e => e.Name).Should().BeEquivalentTo(new[] { "First", "Second" });
+    }
+}

--- a/tests/Application.UnitTests/Common/Queries/GetEntityByIdQueryHandlerTests.cs
+++ b/tests/Application.UnitTests/Common/Queries/GetEntityByIdQueryHandlerTests.cs
@@ -1,0 +1,37 @@
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using LotusFive.Application.Common.Queries;
+using LotusFive.Application.UnitTests.Common;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace LotusFive.Application.UnitTests.Common.Queries;
+
+public class GetEntityByIdQueryHandlerTests
+{
+    [Fact]
+    public async Task Handle_ShouldReturnNull_WhenEntityDoesNotExist()
+    {
+        await using var context = TestAppDbContextFactory.Create();
+        var handler = new GetEntityByIdQueryHandler<TestEntity, int>(context);
+
+        var result = await handler.Handle(new GetEntityByIdQuery<TestEntity, int>(123), CancellationToken.None);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnEntity_WhenFound()
+    {
+        await using var context = TestAppDbContextFactory.Create();
+        context.TestEntities.Add(new TestEntity { Id = 7, Name = "Existing" });
+        await context.SaveChangesAsync();
+        var handler = new GetEntityByIdQueryHandler<TestEntity, int>(context);
+
+        var result = await handler.Handle(new GetEntityByIdQuery<TestEntity, int>(7), CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result!.Name.Should().Be("Existing");
+    }
+}

--- a/tests/Application.UnitTests/Common/TestAppDbContextFactory.cs
+++ b/tests/Application.UnitTests/Common/TestAppDbContextFactory.cs
@@ -1,0 +1,46 @@
+using System;
+using LotusFive.Application.Common.Interfaces;
+using LotusFive.Domain.Common;
+using LotusFive.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace LotusFive.Application.UnitTests.Common;
+
+internal static class TestAppDbContextFactory
+{
+    public static TestAppDbContext Create()
+    {
+        var options = new DbContextOptionsBuilder<TestAppDbContext>()
+            .UseInMemoryDatabase($"LotusFiveTests-{Guid.NewGuid()}")
+            .Options;
+
+        return new TestAppDbContext(options);
+    }
+}
+
+internal sealed class TestAppDbContext : DbContext, IAppDbContext
+{
+    public TestAppDbContext(DbContextOptions<TestAppDbContext> options)
+        : base(options)
+    {
+    }
+
+    public DbSet<TestEntity> TestEntities => Set<TestEntity>();
+    public DbSet<OtpTransaction> OtpTransactions => Set<OtpTransaction>();
+    public DbSet<EmailOtpTransaction> EmailOtpTransactions => Set<EmailOtpTransaction>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        modelBuilder.Entity<TestEntity>().HasKey(e => e.Id);
+        modelBuilder.Entity<OtpTransaction>().HasKey(e => new { e.MobileNo, e.Otp });
+        modelBuilder.Entity<EmailOtpTransaction>().HasKey(e => new { e.EmailId, e.Otp });
+    }
+}
+
+internal sealed class TestEntity : IEntity<int>
+{
+    public int Id { get; set; }
+    public string? Name { get; set; }
+}

--- a/tests/Application.UnitTests/EmailOtpTransactions/Queries/GetEmailOtpTransactionQueryHandlerTests.cs
+++ b/tests/Application.UnitTests/EmailOtpTransactions/Queries/GetEmailOtpTransactionQueryHandlerTests.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using LotusFive.Application.EmailOtpTransactions.Queries;
+using LotusFive.Application.UnitTests.Common;
+using LotusFive.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace LotusFive.Application.UnitTests.EmailOtpTransactions.Queries;
+
+public class GetEmailOtpTransactionQueryHandlerTests
+{
+    [Fact]
+    public async Task Handle_ShouldReturnNull_WhenTransactionDoesNotExist()
+    {
+        await using var context = TestAppDbContextFactory.Create();
+        var handler = new GetEmailOtpTransactionQueryHandler(context);
+
+        var result = await handler.Handle(new GetEmailOtpTransactionQuery("user@example.com", "111111"), CancellationToken.None);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnTransaction_WhenFound()
+    {
+        await using var context = TestAppDbContextFactory.Create();
+        var transaction = new EmailOtpTransaction
+        {
+            EmailId = "user@example.com",
+            Otp = "999999",
+            Status = 1,
+            ExpiryDate = DateTime.UtcNow.AddMinutes(3)
+        };
+        context.EmailOtpTransactions.Add(transaction);
+        await context.SaveChangesAsync();
+        var handler = new GetEmailOtpTransactionQueryHandler(context);
+
+        var result = await handler.Handle(new GetEmailOtpTransactionQuery("user@example.com", "999999"), CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result!.ExpiryDate.Should().Be(transaction.ExpiryDate);
+    }
+}

--- a/tests/Application.UnitTests/OtpTransactions/Queries/GetOtpTransactionQueryHandlerTests.cs
+++ b/tests/Application.UnitTests/OtpTransactions/Queries/GetOtpTransactionQueryHandlerTests.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using LotusFive.Application.OtpTransactions.Queries;
+using LotusFive.Application.UnitTests.Common;
+using LotusFive.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace LotusFive.Application.UnitTests.OtpTransactions.Queries;
+
+public class GetOtpTransactionQueryHandlerTests
+{
+    [Fact]
+    public async Task Handle_ShouldReturnNull_WhenTransactionDoesNotExist()
+    {
+        await using var context = TestAppDbContextFactory.Create();
+        var handler = new GetOtpTransactionQueryHandler(context);
+
+        var result = await handler.Handle(new GetOtpTransactionQuery("0123456789", "123456"), CancellationToken.None);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnTransaction_WhenFound()
+    {
+        await using var context = TestAppDbContextFactory.Create();
+        var transaction = new OtpTransaction
+        {
+            MobileNo = "0123456789",
+            Otp = "654321",
+            Status = 1,
+            ExpiryDate = DateTime.UtcNow.AddMinutes(5)
+        };
+        context.OtpTransactions.Add(transaction);
+        await context.SaveChangesAsync();
+        var handler = new GetOtpTransactionQueryHandler(context);
+
+        var result = await handler.Handle(new GetOtpTransactionQuery("0123456789", "654321"), CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result!.Status.Should().Be(1);
+    }
+}


### PR DESCRIPTION
## Summary
- add an in-memory test DbContext helper for exercising application handlers
- create unit tests covering CRUD command handlers and entity query handlers
- expand controller component tests to include create, update, and delete edge cases

## Testing
- not run (dotnet CLI unavailable in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68da76fafd388321a103e715767ca49f