### PR TITLE
Add logging support to API controllers

### DIFF
--- a/src/Api/Controllers/AuthController.cs
+++ b/src/Api/Controllers/AuthController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.ComponentModel.DataAnnotations;
 using System.Threading;
 using System.Threading.Tasks;
@@ -6,6 +7,7 @@ using LotusFive.Application.Authentication.Commands;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 
 namespace LotusFive.Api.Controllers
 {
@@ -14,22 +16,33 @@ namespace LotusFive.Api.Controllers
     public class AuthController : ControllerBase
     {
         private readonly IMediator _mediator;
+        private readonly ILogger<AuthController> _logger;
 
-        public AuthController(IMediator mediator)
+        public AuthController(IMediator mediator, ILogger<AuthController> logger)
         {
-            _mediator = mediator;
+            _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         [HttpPost("login")]
         [AllowAnonymous]
         public async Task<ActionResult<AuthenticationResult>> Login([FromBody] LoginRequest request, CancellationToken cancellationToken)
         {
+            if (request is null)
+            {
+                _logger.LogWarning("Login request payload was null");
+                return BadRequest();
+            }
+
+            _logger.LogInformation("Attempting to authenticate user {Username}", request.Username);
             var result = await _mediator.Send(new AuthenticateUserCommand(request.Username, request.Password), cancellationToken);
             if (result is null)
             {
+                _logger.LogWarning("Authentication failed for user {Username}", request.Username);
                 return Unauthorized();
             }
 
+            _logger.LogInformation("Successfully authenticated user {Username}", request.Username);
             return Ok(result);
         }
     }

--- a/src/Api/Controllers/BaseEntityController.cs
+++ b/src/Api/Controllers/BaseEntityController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -6,41 +7,54 @@ using LotusFive.Application.Common.Queries;
 using LotusFive.Domain.Common;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 
 namespace LotusFive.Api.Controllers
 {
     public abstract class BaseEntityController<TEntity, TKey> : ControllerBase where TEntity : class, IEntity<TKey>
     {
-        protected IMediator Mediator { get; }
+        private readonly string _entityName;
 
-        protected BaseEntityController(IMediator mediator)
+        protected IMediator Mediator { get; }
+        protected ILogger<BaseEntityController<TEntity, TKey>> Logger { get; }
+
+        protected BaseEntityController(IMediator mediator, ILogger<BaseEntityController<TEntity, TKey>> logger)
         {
-            Mediator = mediator;
+            Mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
+            Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _entityName = typeof(TEntity).Name;
         }
 
         [HttpGet]
         public virtual async Task<ActionResult<IEnumerable<TEntity>>> GetAll(CancellationToken cancellationToken)
         {
+            Logger.LogInformation("Fetching all {EntityName} entities", _entityName);
             var result = await Mediator.Send(new GetAllEntitiesQuery<TEntity>(), cancellationToken);
+            Logger.LogInformation("Successfully fetched all {EntityName} entities", _entityName);
             return Ok(result);
         }
 
         [HttpGet("{id}")]
         public virtual async Task<ActionResult<TEntity>> GetById(TKey id, CancellationToken cancellationToken)
         {
+            Logger.LogInformation("Fetching {EntityName} with id {EntityId}", _entityName, id);
             var entity = await Mediator.Send(new GetEntityByIdQuery<TEntity, TKey>(id), cancellationToken);
             if (entity == null)
             {
+                Logger.LogWarning("{EntityName} with id {EntityId} was not found", _entityName, id);
                 return NotFound();
             }
 
+            Logger.LogInformation("Successfully fetched {EntityName} with id {EntityId}", _entityName, id);
             return Ok(entity);
         }
 
         [HttpPost]
         public virtual async Task<ActionResult<TEntity>> Create([FromBody] TEntity entity, CancellationToken cancellationToken)
         {
+            Logger.LogInformation("Creating a new {EntityName}", _entityName);
             var created = await Mediator.Send(new CreateEntityCommand<TEntity>(entity), cancellationToken);
+            Logger.LogInformation("Successfully created {EntityName} with id {EntityId}", _entityName, GetEntityId(created));
             return CreatedAtAction(nameof(GetById), new { id = GetEntityId(created) }, created);
         }
 
@@ -49,27 +63,34 @@ namespace LotusFive.Api.Controllers
         {
             if (!EqualityComparer<TKey>.Default.Equals(id, ((IEntity<TKey>)entity).Id))
             {
+                Logger.LogWarning("Attempt to update {EntityName} with mismatched id. Route id: {RouteId}, Entity id: {EntityId}", _entityName, id, ((IEntity<TKey>)entity).Id);
                 return BadRequest();
             }
 
+            Logger.LogInformation("Updating {EntityName} with id {EntityId}", _entityName, id);
             var updated = await Mediator.Send(new UpdateEntityCommand<TEntity, TKey>(id, entity), cancellationToken);
             if (updated == null)
             {
+                Logger.LogWarning("{EntityName} with id {EntityId} was not found for update", _entityName, id);
                 return NotFound();
             }
 
+            Logger.LogInformation("Successfully updated {EntityName} with id {EntityId}", _entityName, id);
             return Ok(updated);
         }
 
         [HttpDelete("{id}")]
         public virtual async Task<IActionResult> Delete(TKey id, CancellationToken cancellationToken)
         {
+            Logger.LogInformation("Deleting {EntityName} with id {EntityId}", _entityName, id);
             var deleted = await Mediator.Send(new DeleteEntityCommand<TEntity, TKey>(id), cancellationToken);
             if (!deleted)
             {
+                Logger.LogWarning("{EntityName} with id {EntityId} was not found for deletion", _entityName, id);
                 return NotFound();
             }
 
+            Logger.LogInformation("Successfully deleted {EntityName} with id {EntityId}", _entityName, id);
             return NoContent();
         }
 

--- a/src/Api/Controllers/BeneficiaryDetailsController.cs
+++ b/src/Api/Controllers/BeneficiaryDetailsController.cs
@@ -1,6 +1,7 @@
 using LotusFive.Domain.Entities;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 
 namespace LotusFive.Api.Controllers
 {
@@ -8,7 +9,7 @@ namespace LotusFive.Api.Controllers
     [Route("api/[controller]")]
     public class BeneficiaryDetailsController : BaseEntityController<BeneficiaryDetail, string>
     {
-        public BeneficiaryDetailsController(IMediator mediator) : base(mediator)
+        public BeneficiaryDetailsController(IMediator mediator, ILogger<BaseEntityController<BeneficiaryDetail, string>> logger) : base(mediator, logger)
         {
         }
     }

--- a/src/Api/Controllers/BranchesController.cs
+++ b/src/Api/Controllers/BranchesController.cs
@@ -1,6 +1,7 @@
 using LotusFive.Domain.Entities;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 
 namespace LotusFive.Api.Controllers
 {
@@ -8,7 +9,7 @@ namespace LotusFive.Api.Controllers
     [Route("api/[controller]")]
     public class BranchesController : BaseEntityController<Branch, string>
     {
-        public BranchesController(IMediator mediator) : base(mediator)
+        public BranchesController(IMediator mediator, ILogger<BaseEntityController<Branch, string>> logger) : base(mediator, logger)
         {
         }
     }

--- a/src/Api/Controllers/CampaignsController.cs
+++ b/src/Api/Controllers/CampaignsController.cs
@@ -1,6 +1,7 @@
 using LotusFive.Domain.Entities;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 
 namespace LotusFive.Api.Controllers
 {
@@ -8,7 +9,7 @@ namespace LotusFive.Api.Controllers
     [Route("api/[controller]")]
     public class CampaignsController : BaseEntityController<Campaign, string>
     {
-        public CampaignsController(IMediator mediator) : base(mediator)
+        public CampaignsController(IMediator mediator, ILogger<BaseEntityController<Campaign, string>> logger) : base(mediator, logger)
         {
         }
     }

--- a/src/Api/Controllers/CountriesController.cs
+++ b/src/Api/Controllers/CountriesController.cs
@@ -1,6 +1,7 @@
 using LotusFive.Domain.Entities;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 
 namespace LotusFive.Api.Controllers
 {
@@ -8,7 +9,7 @@ namespace LotusFive.Api.Controllers
     [Route("api/[controller]")]
     public class CountriesController : BaseEntityController<Country, int>
     {
-        public CountriesController(IMediator mediator) : base(mediator)
+        public CountriesController(IMediator mediator, ILogger<BaseEntityController<Country, int>> logger) : base(mediator, logger)
         {
         }
     }

--- a/src/Api/Controllers/CurrencyRatesController.cs
+++ b/src/Api/Controllers/CurrencyRatesController.cs
@@ -1,6 +1,7 @@
 using LotusFive.Domain.Entities;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 
 namespace LotusFive.Api.Controllers
 {
@@ -8,7 +9,7 @@ namespace LotusFive.Api.Controllers
     [Route("api/[controller]")]
     public class CurrencyRatesController : BaseEntityController<CurrencyRate, string>
     {
-        public CurrencyRatesController(IMediator mediator) : base(mediator)
+        public CurrencyRatesController(IMediator mediator, ILogger<BaseEntityController<CurrencyRate, string>> logger) : base(mediator, logger)
         {
         }
     }

--- a/src/Api/Controllers/CustomerRegistrationsController.cs
+++ b/src/Api/Controllers/CustomerRegistrationsController.cs
@@ -1,6 +1,7 @@
 using LotusFive.Domain.Entities;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 
 namespace LotusFive.Api.Controllers
 {
@@ -8,7 +9,7 @@ namespace LotusFive.Api.Controllers
     [Route("api/[controller]")]
     public class CustomerRegistrationsController : BaseEntityController<CustomerRegistration, string>
     {
-        public CustomerRegistrationsController(IMediator mediator) : base(mediator)
+        public CustomerRegistrationsController(IMediator mediator, ILogger<BaseEntityController<CustomerRegistration, string>> logger) : base(mediator, logger)
         {
         }
     }

--- a/src/Api/Controllers/CustomerTransactionsController.cs
+++ b/src/Api/Controllers/CustomerTransactionsController.cs
@@ -1,6 +1,7 @@
 using LotusFive.Domain.Entities;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 
 namespace LotusFive.Api.Controllers
 {
@@ -8,7 +9,7 @@ namespace LotusFive.Api.Controllers
     [Route("api/[controller]")]
     public class CustomerTransactionsController : BaseEntityController<CustomerTransaction, string>
     {
-        public CustomerTransactionsController(IMediator mediator) : base(mediator)
+        public CustomerTransactionsController(IMediator mediator, ILogger<BaseEntityController<CustomerTransaction, string>> logger) : base(mediator, logger)
         {
         }
     }

--- a/src/Api/Controllers/DocumentsController.cs
+++ b/src/Api/Controllers/DocumentsController.cs
@@ -1,6 +1,7 @@
 using LotusFive.Domain.Entities;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 
 namespace LotusFive.Api.Controllers
 {
@@ -8,7 +9,7 @@ namespace LotusFive.Api.Controllers
     [Route("api/[controller]")]
     public class DocumentsController : BaseEntityController<Document, string>
     {
-        public DocumentsController(IMediator mediator) : base(mediator)
+        public DocumentsController(IMediator mediator, ILogger<BaseEntityController<Document, string>> logger) : base(mediator, logger)
         {
         }
     }

--- a/src/Api/Controllers/EmailOtpTransactionsController.cs
+++ b/src/Api/Controllers/EmailOtpTransactionsController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using LotusFive.Application.Common.Commands;
 using LotusFive.Application.Common.Queries;
@@ -5,6 +6,7 @@ using LotusFive.Application.EmailOtpTransactions.Queries;
 using LotusFive.Domain.Entities;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 
 namespace LotusFive.Api.Controllers
 {
@@ -13,35 +15,50 @@ namespace LotusFive.Api.Controllers
     public class EmailOtpTransactionsController : ControllerBase
     {
         private readonly IMediator _mediator;
+        private readonly ILogger<EmailOtpTransactionsController> _logger;
 
-        public EmailOtpTransactionsController(IMediator mediator)
+        public EmailOtpTransactionsController(IMediator mediator, ILogger<EmailOtpTransactionsController> logger)
         {
-            _mediator = mediator;
+            _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         [HttpGet]
         public async Task<ActionResult<IEnumerable<EmailOtpTransaction>>> GetAll(CancellationToken cancellationToken)
         {
+            _logger.LogInformation("Fetching all email OTP transactions");
             var result = await _mediator.Send(new GetAllEntitiesQuery<EmailOtpTransaction>(), cancellationToken);
+            _logger.LogInformation("Successfully fetched all email OTP transactions");
             return Ok(result);
         }
 
         [HttpGet("{emailId}/{otp}")]
         public async Task<ActionResult<EmailOtpTransaction>> GetById(string emailId, string otp, CancellationToken cancellationToken)
         {
+            _logger.LogInformation("Fetching email OTP transaction for email {EmailId} and OTP {Otp}", emailId, otp);
             var entity = await _mediator.Send(new GetEmailOtpTransactionQuery(emailId, otp), cancellationToken);
             if (entity == null)
             {
+                _logger.LogWarning("Email OTP transaction for email {EmailId} and OTP {Otp} was not found", emailId, otp);
                 return NotFound();
             }
 
+            _logger.LogInformation("Successfully fetched email OTP transaction for email {EmailId} and OTP {Otp}", emailId, otp);
             return Ok(entity);
         }
 
         [HttpPost]
         public async Task<ActionResult<EmailOtpTransaction>> Create([FromBody] EmailOtpTransaction transaction, CancellationToken cancellationToken)
         {
+            if (transaction == null)
+            {
+                _logger.LogWarning("Attempted to create email OTP transaction with null payload");
+                return BadRequest();
+            }
+
+            _logger.LogInformation("Creating email OTP transaction for email {EmailId}", transaction.EmailId);
             var created = await _mediator.Send(new CreateEntityCommand<EmailOtpTransaction>(transaction), cancellationToken);
+            _logger.LogInformation("Successfully created email OTP transaction for email {EmailId} and OTP {Otp}", created.EmailId, created.Otp);
             return CreatedAtAction(nameof(GetById), new { emailId = created.EmailId, otp = created.Otp }, created);
         }
     }

--- a/src/Api/Controllers/EntrySourcesController.cs
+++ b/src/Api/Controllers/EntrySourcesController.cs
@@ -1,6 +1,7 @@
 using LotusFive.Domain.Entities;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 
 namespace LotusFive.Api.Controllers
 {
@@ -8,7 +9,7 @@ namespace LotusFive.Api.Controllers
     [Route("api/[controller]")]
     public class EntrySourcesController : BaseEntityController<EntrySource, int>
     {
-        public EntrySourcesController(IMediator mediator) : base(mediator)
+        public EntrySourcesController(IMediator mediator, ILogger<BaseEntityController<EntrySource, int>> logger) : base(mediator, logger)
         {
         }
     }

--- a/src/Api/Controllers/FpxBanksController.cs
+++ b/src/Api/Controllers/FpxBanksController.cs
@@ -1,6 +1,7 @@
 using LotusFive.Domain.Entities;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 
 namespace LotusFive.Api.Controllers
 {
@@ -8,7 +9,7 @@ namespace LotusFive.Api.Controllers
     [Route("api/[controller]")]
     public class FpxBanksController : BaseEntityController<FpxBank, int>
     {
-        public FpxBanksController(IMediator mediator) : base(mediator)
+        public FpxBanksController(IMediator mediator, ILogger<BaseEntityController<FpxBank, string>> logger) : base(mediator, logger)
         {
         }
     }

--- a/src/Api/Controllers/FpxConfigurationsController.cs
+++ b/src/Api/Controllers/FpxConfigurationsController.cs
@@ -1,6 +1,7 @@
 using LotusFive.Domain.Entities;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 
 namespace LotusFive.Api.Controllers
 {
@@ -8,7 +9,7 @@ namespace LotusFive.Api.Controllers
     [Route("api/[controller]")]
     public class FpxConfigurationsController : BaseEntityController<FpxConfiguration, int>
     {
-        public FpxConfigurationsController(IMediator mediator) : base(mediator)
+        public FpxConfigurationsController(IMediator mediator, ILogger<BaseEntityController<FpxConfiguration, int>> logger) : base(mediator, logger)
         {
         }
     }

--- a/src/Api/Controllers/FpxResponsesController.cs
+++ b/src/Api/Controllers/FpxResponsesController.cs
@@ -1,6 +1,7 @@
 using LotusFive.Domain.Entities;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 
 namespace LotusFive.Api.Controllers
 {
@@ -8,7 +9,7 @@ namespace LotusFive.Api.Controllers
     [Route("api/[controller]")]
     public class FpxResponsesController : BaseEntityController<FpxResponse, string>
     {
-        public FpxResponsesController(IMediator mediator) : base(mediator)
+        public FpxResponsesController(IMediator mediator, ILogger<BaseEntityController<FpxResponse, string>> logger) : base(mediator, logger)
         {
         }
     }

--- a/src/Api/Controllers/NationalitiesController.cs
+++ b/src/Api/Controllers/NationalitiesController.cs
@@ -1,6 +1,7 @@
 using LotusFive.Domain.Entities;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 
 namespace LotusFive.Api.Controllers
 {
@@ -8,7 +9,7 @@ namespace LotusFive.Api.Controllers
     [Route("api/[controller]")]
     public class NationalitiesController : BaseEntityController<Nationality, int>
     {
-        public NationalitiesController(IMediator mediator) : base(mediator)
+        public NationalitiesController(IMediator mediator, ILogger<BaseEntityController<Nationality, int>> logger) : base(mediator, logger)
         {
         }
     }

--- a/src/Api/Controllers/OtpTransactionsController.cs
+++ b/src/Api/Controllers/OtpTransactionsController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using LotusFive.Application.Common.Commands;
 using LotusFive.Application.Common.Queries;
@@ -5,6 +6,7 @@ using LotusFive.Application.OtpTransactions.Queries;
 using LotusFive.Domain.Entities;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 
 namespace LotusFive.Api.Controllers
 {
@@ -13,35 +15,50 @@ namespace LotusFive.Api.Controllers
     public class OtpTransactionsController : ControllerBase
     {
         private readonly IMediator _mediator;
+        private readonly ILogger<OtpTransactionsController> _logger;
 
-        public OtpTransactionsController(IMediator mediator)
+        public OtpTransactionsController(IMediator mediator, ILogger<OtpTransactionsController> logger)
         {
-            _mediator = mediator;
+            _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         [HttpGet]
         public async Task<ActionResult<IEnumerable<OtpTransaction>>> GetAll(CancellationToken cancellationToken)
         {
+            _logger.LogInformation("Fetching all OTP transactions");
             var result = await _mediator.Send(new GetAllEntitiesQuery<OtpTransaction>(), cancellationToken);
+            _logger.LogInformation("Successfully fetched all OTP transactions");
             return Ok(result);
         }
 
         [HttpGet("{mobileNo}/{otp}")]
         public async Task<ActionResult<OtpTransaction>> GetById(string mobileNo, string otp, CancellationToken cancellationToken)
         {
+            _logger.LogInformation("Fetching OTP transaction for mobile {MobileNo} and OTP {Otp}", mobileNo, otp);
             var entity = await _mediator.Send(new GetOtpTransactionQuery(mobileNo, otp), cancellationToken);
             if (entity == null)
             {
+                _logger.LogWarning("OTP transaction for mobile {MobileNo} and OTP {Otp} was not found", mobileNo, otp);
                 return NotFound();
             }
 
+            _logger.LogInformation("Successfully fetched OTP transaction for mobile {MobileNo} and OTP {Otp}", mobileNo, otp);
             return Ok(entity);
         }
 
         [HttpPost]
         public async Task<ActionResult<OtpTransaction>> Create([FromBody] OtpTransaction transaction, CancellationToken cancellationToken)
         {
+            if (transaction == null)
+            {
+                _logger.LogWarning("Attempted to create OTP transaction with null payload");
+                return BadRequest();
+            }
+
+            _logger.LogInformation("Creating OTP transaction for mobile {MobileNo}", transaction.MobileNo);
             var created = await _mediator.Send(new CreateEntityCommand<OtpTransaction>(transaction), cancellationToken);
+            _logger.LogInformation("Successfully created OTP transaction for mobile {MobileNo} and OTP {Otp}", created.MobileNo, created.Otp);
             return CreatedAtAction(nameof(GetById), new { mobileNo = created.MobileNo, otp = created.Otp }, created);
         }
     }

--- a/src/Api/Controllers/PromotionsController.cs
+++ b/src/Api/Controllers/PromotionsController.cs
@@ -1,6 +1,7 @@
 using LotusFive.Domain.Entities;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 
 namespace LotusFive.Api.Controllers
 {
@@ -8,7 +9,7 @@ namespace LotusFive.Api.Controllers
     [Route("api/[controller]")]
     public class PromotionsController : BaseEntityController<Promotion, string>
     {
-        public PromotionsController(IMediator mediator) : base(mediator)
+        public PromotionsController(IMediator mediator, ILogger<BaseEntityController<Promotion, string>> logger) : base(mediator, logger)
         {
         }
     }

--- a/src/Api/Controllers/TransferFeesController.cs
+++ b/src/Api/Controllers/TransferFeesController.cs
@@ -1,6 +1,7 @@
 using LotusFive.Domain.Entities;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 
 namespace LotusFive.Api.Controllers
 {
@@ -8,7 +9,7 @@ namespace LotusFive.Api.Controllers
     [Route("api/[controller]")]
     public class TransferFeesController : BaseEntityController<TransferFee, string>
     {
-        public TransferFeesController(IMediator mediator) : base(mediator)
+        public TransferFeesController(IMediator mediator, ILogger<BaseEntityController<TransferFee, string>> logger) : base(mediator, logger)
         {
         }
     }


### PR DESCRIPTION
## Summary
- add structured logging to the shared BaseEntityController so CRUD actions emit informative events
- require logger dependencies in entity controllers and add targeted logging to authentication and OTP workflows

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68de55281ba48321930d1fe9685b8f01