### PR TITLE
Register open generic MediatR handlers

### DIFF
--- a/src/Application/ServiceCollectionExtensions.cs
+++ b/src/Application/ServiceCollectionExtensions.cs
@@ -1,5 +1,8 @@
 using System.Reflection;
+using LotusFive.Application.Common.Commands;
+using LotusFive.Application.Common.Queries;
 using MediatR;
+using MediatR.Registration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace LotusFive.Application
@@ -8,7 +11,15 @@ namespace LotusFive.Application
     {
         public static IServiceCollection AddApplication(this IServiceCollection services)
         {
-            services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblies(Assembly.GetExecutingAssembly()));
+            services.AddMediatR(cfg =>
+            {
+                cfg.RegisterServicesFromAssemblies(Assembly.GetExecutingAssembly());
+                cfg.AddOpenRequestHandlerWithResponse(typeof(GetAllEntitiesQuery<>), typeof(GetAllEntitiesQueryHandler<>));
+                cfg.AddOpenRequestHandlerWithResponse(typeof(GetEntityByIdQuery<,>), typeof(GetEntityByIdQueryHandler<,>));
+                cfg.AddOpenRequestHandlerWithResponse(typeof(CreateEntityCommand<>), typeof(CreateEntityCommandHandler<>));
+                cfg.AddOpenRequestHandlerWithResponse(typeof(UpdateEntityCommand<,>), typeof(UpdateEntityCommandHandler<,>));
+                cfg.AddOpenRequestHandlerWithResponse(typeof(DeleteEntityCommand<,>), typeof(DeleteEntityCommandHandler<,>));
+            });
             return services;
         }
     }


### PR DESCRIPTION
## Summary
- register the common open-generic query and command handlers with MediatR so they can be resolved by DI
- add the necessary namespace imports for the shared handler types

## Testing
- `dotnet build LotusApi2025.sln` *(fails: `dotnet` CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de633875a8832192a4d26d3890fe04