### PR TITLE
Register generic MediatR handlers

### DIFF
--- a/src/Application/ServiceCollectionExtensions.cs
+++ b/src/Application/ServiceCollectionExtensions.cs
@@ -14,12 +14,13 @@ namespace LotusFive.Application
             services.AddMediatR(cfg =>
             {
                 cfg.RegisterServicesFromAssemblies(Assembly.GetExecutingAssembly());
-                cfg.AddOpenRequestHandlerWithResponse(typeof(GetAllEntitiesQuery<>), typeof(GetAllEntitiesQueryHandler<>));
-                cfg.AddOpenRequestHandlerWithResponse(typeof(GetEntityByIdQuery<,>), typeof(GetEntityByIdQueryHandler<,>));
-                cfg.AddOpenRequestHandlerWithResponse(typeof(CreateEntityCommand<>), typeof(CreateEntityCommandHandler<>));
-                cfg.AddOpenRequestHandlerWithResponse(typeof(UpdateEntityCommand<,>), typeof(UpdateEntityCommandHandler<,>));
-                cfg.AddOpenRequestHandlerWithResponse(typeof(DeleteEntityCommand<,>), typeof(DeleteEntityCommandHandler<,>));
             });
+
+            services.AddTransient(typeof(IRequestHandler<,>), typeof(GetAllEntitiesQueryHandler<>));
+            services.AddTransient(typeof(IRequestHandler<,>), typeof(GetEntityByIdQueryHandler<,>));
+            services.AddTransient(typeof(IRequestHandler<,>), typeof(CreateEntityCommandHandler<>));
+            services.AddTransient(typeof(IRequestHandler<,>), typeof(UpdateEntityCommandHandler<,>));
+            services.AddTransient(typeof(IRequestHandler<,>), typeof(DeleteEntityCommandHandler<,>));
             return services;
         }
     }


### PR DESCRIPTION
## Summary
- ensure the MediatR configuration registers the open generic CRUD handlers
- allow controllers to resolve the shared query and command handlers at runtime

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68de6b7c42a8832181dd4b8c73df8055