### PR TITLE
Remove redundant manual MediatR handler registrations

### DIFF
--- a/src/Application/ServiceCollectionExtensions.cs
+++ b/src/Application/ServiceCollectionExtensions.cs
@@ -1,6 +1,4 @@
 using System.Reflection;
-using LotusFive.Application.Common.Commands;
-using LotusFive.Application.Common.Queries;
 using MediatR;
 using MediatR.Registration;
 using Microsoft.Extensions.DependencyInjection;
@@ -16,11 +14,6 @@ namespace LotusFive.Application
                 cfg.RegisterServicesFromAssemblies(Assembly.GetExecutingAssembly());
             });
 
-            services.AddTransient(typeof(IRequestHandler<,>), typeof(GetAllEntitiesQueryHandler<>));
-            services.AddTransient(typeof(IRequestHandler<,>), typeof(GetEntityByIdQueryHandler<,>));
-            services.AddTransient(typeof(IRequestHandler<,>), typeof(CreateEntityCommandHandler<>));
-            services.AddTransient(typeof(IRequestHandler<,>), typeof(UpdateEntityCommandHandler<,>));
-            services.AddTransient(typeof(IRequestHandler<,>), typeof(DeleteEntityCommandHandler<,>));
             return services;
         }
     }


### PR DESCRIPTION
## Summary
- remove explicit registrations of open generic MediatR handlers to avoid invalid arity bindings
- rely on MediatR assembly scanning to discover handlers automatically

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68de6ff707b483218bf4574e5edbb387